### PR TITLE
Bumped `Candoumbe.Pipelines`

### DIFF
--- a/build/Pipelines.csproj
+++ b/build/Pipelines.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="6.3.0" />
-    <PackageReference Include="Candoumbe.Pipelines" Version="0.3.0-alpha0011" />
+    <PackageReference Include="Candoumbe.Pipelines" Version="0.3.0-beta0001" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bumped `Candoumbe.Pipelines` to 0.3.0-beta0001 which prevents `develop` branch to publish packages