### PR TITLE
[COLDFIX] Incorrect Repository Url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### 🚀 New features
 - Added `NonNegativeInteger` type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
 - Added `PositiveInteger` type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
+
+### 🧹 Housekeeping
+- Fixed incorrect package and repository urls which caused report of mutation tests to not be sent.
 
 ## [0.1.0] / 2023-01-29
 - Initial release

--- a/core.props
+++ b/core.props
@@ -3,7 +3,7 @@
     <LangVersion>latest</LangVersion>
     <Authors>Cyrille NDOUMBE</Authors>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/candoumbe/DataFilters</RepositoryUrl>
+    <RepositoryUrl>https://github.com/candoumbe/Candoumbe.Types</RepositoryUrl>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <PublishUrl>true</PublishUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>


### PR DESCRIPTION
### 🚀 New features
• Added NonNegativeInteger type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
• Added PositiveInteger type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
### 🧹 Housekeeping
• Fixed incorrect package and repository urls which caused report of mutation tests to not be sent.

Full changelog at https://github.com/candoumbe/Candoumbe.Types/blob/coldfix/incorrect-repository-url/CHANGELOG.md