### PR TITLE
✨ Freeze Fluent Assertions To Version 7

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,8 @@
 [*]
 end_of_line = crlf
 
+[{*.csproj,*.json,*.xml,*.props}]
+indent_size = 2
 [*.cs]
 # Style options
 csharp_style_expression_bodied_accessors = when_on_single_line:suggestion

--- a/.gitignore
+++ b/.gitignore
@@ -477,3 +477,5 @@ $RECYCLE.BIN/
 *.lnk
 # Nuke temporary directory
 /.nuke/temp
+
+.qodo

--- a/.nuke/parameters.local.json
+++ b/.nuke/parameters.local.json
@@ -1,5 +1,0 @@
-{
-  "GitHubToken": "v1:Rgp0YSiizCZNIoK6m7DVOZ1q3Ff0jEt+YHepPAOlWriv+3wvWOQzxmkVRrZgeLrJxoQ2jHXjeO44NhL0IM8X34p1GLyPrVO8/39PfpJDrQnsSHDaAXBpjc8xxamM07GM",
-  "NugetApiKey": "v1:AsbGEV2mlCSWbfK7gFyKuLzhQ34i2ON1raQewdVqaIMyIi1d/WRp4KPl7f+naTPd",
-  "StrykerDashboardApiKey": "v1:eaOFQEZbWF9zGMb72JBEwzIqr/dxmGkkqC8s9rcUW/4d21LzmkL2w6337zmp2/vi"
-}

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,9 +1,12 @@
 mode: ContinuousDeployment
 branches: 
   feature: 
-    regex: "^feature(s)?[/-]"
+    regex: "^feature(s)?[/-](?<BranchName>.+)"
+    mode: ContinuousDelivery
+    label: '{BranchName}'
+    increment: Inherit
   coldfix:
-    regex: "^coldfix(es)?[/-]"
+    regex: "^coldfix(es)?[/-](?<BranchName>.+)"
     mode: ContinuousDelivery
     label: '{BranchName}'
     increment: Inherit

--- a/build.ps1
+++ b/build.ps1
@@ -18,11 +18,10 @@ $TempDirectory = "$PSScriptRoot\\.nuke\temp"
 
 $DotNetGlobalFile = "$PSScriptRoot\\global.json"
 $DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
-$DotNetChannel = "Current"
+$DotNetChannel = "STS"
 
-$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
 $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
-$env:DOTNET_MULTILEVEL_LOOKUP = 0
+$env:DOTNET_NOLOGO = 1
 
 ###########################################################################
 # EXECUTION
@@ -61,9 +60,15 @@ else {
         ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Version $DotNetVersion -NoPath }
     }
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
+    $env:PATH = "$DotNetDirectory;$env:PATH"
 }
 
 Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
+
+if (Test-Path env:NUKE_ENTERPRISE_TOKEN) {
+    & $env:DOTNET_EXE nuget remove source "nuke-enterprise" > $null
+    & $env:DOTNET_EXE nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password $env:NUKE_ENTERPRISE_TOKEN > $null
+}
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -14,11 +14,10 @@ TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
 
 DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
 DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
-DOTNET_CHANNEL="Current"
+DOTNET_CHANNEL="STS"
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-export DOTNET_MULTILEVEL_LOOKUP=0
+export DOTNET_NOLOGO=1
 
 ###########################################################################
 # EXECUTION
@@ -54,9 +53,15 @@ else
         "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "$DOTNET_VERSION" --no-path
     fi
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
+    export PATH="$DOTNET_DIRECTORY:$PATH"
 fi
 
 echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
+
+if [[ ! -z ${NUKE_ENTERPRISE_TOKEN+x} && "$NUKE_ENTERPRISE_TOKEN" != "" ]]; then
+    "$DOTNET_EXE" nuget remove source "nuke-enterprise" &>/dev/null || true
+    "$DOTNET_EXE" nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password "$NUKE_ENTERPRISE_TOKEN" --store-password-in-clear-text &>/dev/null || true
+fi
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/Pipelines.cs
+++ b/build/Pipelines.cs
@@ -6,14 +6,12 @@ using Candoumbe.Pipelines.Components.GitHub;
 using Candoumbe.Pipelines.Components.NuGet;
 using Candoumbe.Pipelines.Components.Workflows;
 using Nuke.Common;
-using Nuke.Common.CI;
 using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.Codecov;
 using Nuke.Common.Tools.GitHub;
-using Nuke.Common.Utilities.Collections;
 
 [GitHubActions("integration", GitHubActionsImage.UbuntuLatest,
     AutoGenerate = false,
@@ -131,10 +129,6 @@ public class Pipelines : EnhancedNukeBuild,
     ICreateGithubRelease,
     IGitFlowWithPullRequest
 {
-
-    [CI]
-    public GitHubActions GitHubActions;
-
     [Required]
     [Solution]
     public Solution Solution;

--- a/build/Pipelines.csproj
+++ b/build/Pipelines.csproj
@@ -8,18 +8,16 @@
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
-      <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
-</PropertyGroup>
+  </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Candoumbe.Pipelines" Version="0.12.1" />
+    <PackageReference Include="Candoumbe.Pipelines" Version="0.12.1"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="GitVersion.Tool" Version="[6.0.5]" />
-    <PackageDownload Include="CodeCov.Tool" Version="[1.13.0]" />
-    <PackageDownload Include="CodecovUploader" Version="[0.8.0]" />
-    <PackageDownload Include="ReportGenerator" Version="[5.1.13]" />
+    <PackageDownload Include="GitVersion.Tool" Version="[6.0.5]"/>
+    <PackageDownload Include="CodeCov.Tool" Version="[1.13.0]"/>
+    <PackageDownload Include="CodecovUploader" Version="[0.8.0]"/>
+    <PackageDownload Include="ReportGenerator" Version="[5.1.13]"/>
   </ItemGroup>
-
 </Project>

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,12 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":approveMajorUpdates",
+    ":assignee(candoumbe)",
+    ":reviewer(candoumbe)",
+    ":automergePatch",
+    ":automergeStableNonMajor"
   ],
-  "assignees": [ "candoumbe" ],
-  "addLabels": [ "package-update" ],
-  "automerge": true
+  "addLabels": [ "renovate", "package-update" ],
+  "automergeStrategy": "rebase"
 }

--- a/src/Candoumbe.Types/Calendar/TimeOnlyRange.cs
+++ b/src/Candoumbe.Types/Calendar/TimeOnlyRange.cs
@@ -38,6 +38,9 @@ public record TimeOnlyRange : Range<TimeOnly>
     , IUnaryNegationOperators<TimeOnlyRange, TimeOnlyRange>
 #endif
 {
+    /// <summary>
+    /// Duration of the current range as a <see cref="TimeSpan"/>.
+    /// </summary>
     public TimeSpan Span => Start <= End ? End - Start : Start - End;
 
     /// <summary>

--- a/src/Candoumbe.Types/ICanRepresentEmpty.cs
+++ b/src/Candoumbe.Types/ICanRepresentEmpty.cs
@@ -15,10 +15,8 @@ public interface ICanRepresentEmpty<in TInterval, TBound> where TInterval : IRan
     static TInterval Empty { get; }
 
     /// <summary>
-    /// Checks if <paramref name="range"/> is empty (by <typeparamref name="TInterval"/>'s definition)
+    /// Checks if the current instance is empty (by <typeparamref name="TInterval"/>'s definition)
     /// </summary>
-    /// <param name="range"></param>
     /// <returns><see langword="true"/> if range is empty or <see langword="false"/> otherwise.</returns>
-    /// <exception cref="ArgumentNullException">if <paramref name="range"/> is <see langword="null"/></exception>
     bool IsEmpty();
 }

--- a/src/Candoumbe.Types/Strings/StringSegmentLinkedList.cs
+++ b/src/Candoumbe.Types/Strings/StringSegmentLinkedList.cs
@@ -350,6 +350,15 @@ public class StringSegmentLinkedList : IEnumerable<ReadOnlyMemory<char>>
         return replacementList;
     }
 
+    /// <summary>
+    /// Replaces characters that matches <paramref name="predicate"/>.
+    /// </summary>
+    /// <param name="predicate">The predicate to select characters to replace.</param>
+    /// <param name="replacement">A dictionary mapping characters with their replacement value.</param>
+    /// <returns>A new instance where all characters which match <paramref name="predicate"/> were replaced.</returns>
+    /// <remarks>
+    /// This method will simply remove any character that matches <paramref name="predicate"/> but for which no suitable mapping was found in <paramref name="replacement"/>.
+    /// </remarks>
     public StringSegmentLinkedList Replace(Func<char, bool> predicate, IReadOnlyDictionary<char, ReadOnlyMemory<char>> replacement)
     {
         StringSegmentLinkedList replacementList = [];

--- a/tests.props
+++ b/tests.props
@@ -7,7 +7,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1"/>
         <PackageReference Include="xunit.categories" Version="2.0.8"/>
-        <PackageReference Include="FluentAssertions" Version="8.0.0"/>
+        <PackageReference Include="FluentAssertions" Version="7.0.0"/>
         <PackageReference Include="FsCheck.XUnit" Version="3.0.0"/>
         <PackageReference Include="coverlet.msbuild" Version="6.0.3"/>
         <PackageReference Include="Moq" Version="4.20.71"/>

--- a/tests.props
+++ b/tests.props
@@ -1,17 +1,17 @@
 <Project>
-    <Import Project=".\core.props"/>
-    <PropertyGroup>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1"/>
-        <PackageReference Include="xunit.categories" Version="2.0.8"/>
-        <PackageReference Include="FluentAssertions" Version="7.0.0"/>
-        <PackageReference Include="FsCheck.XUnit" Version="3.0.0"/>
-        <PackageReference Include="coverlet.msbuild" Version="6.0.3"/>
-        <PackageReference Include="Moq" Version="4.20.71"/>
-        <PackageReference Include="NodaTime.Bogus" Version="3.0.2"/>
-        <PackageReference Include="Bogus" Version="35.6.1"/>
-    </ItemGroup>
+  <Import Project=".\core.props"/>
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1"/>
+    <PackageReference Include="xunit.categories" Version="2.0.8"/>
+    <PackageReference Include="FluentAssertions" Version="7.0.0"/>
+    <PackageReference Include="FsCheck.XUnit" Version="3.0.0"/>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.3"/>
+    <PackageReference Include="Moq" Version="4.20.71"/>
+    <PackageReference Include="NodaTime.Bogus" Version="3.0.2"/>
+    <PackageReference Include="Bogus" Version="35.6.1"/>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
### 🚀 New features
• Added NonNegativeInteger type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
• Added PositiveInteger type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
• Added net8.0 support
• Added [StringSegmentLinkedList](./src/Candoumbe.Types/Strings/StringSegmentLinkedList.cs) type
• Added collection expression support for MultiTimeOnlyRange%2C MultiDateTimeRange and MultiDateOnlyRange ([#205](https://github.com/candoumbe/candoumbe.types/issues/205))
• Added [IRange](./src/Candoumbe.Types/IRange.cs) interface
• Added [ICanRepresentEmpty](./src/Candoumbe.Types/ICanRepresentEmpty.cs) interface
• Added [ICanRepresentInfinite](./src/Candoumbe.Types/ICanRepresentInfinite.cs) interface
### 🚨 Breaking changes
• Dropped net6.0 support as it's no longer maintained by Microsoft ([#216](https://github.com/candoumbe/Candoumbe.Types/issues/216)).
• Dropped net7.0 support as it's no longer maintained by Microsoft.
• Removed Ranges property from [MultiDateTimeRange](./src/Candoumbe.Types/Calendar/MultiDateTimeRange.cs)%2C [MultiTimeOnlyRange](./src/Candoumbe.Types/Calendar/MultiTimeOnlyRange.cs) and [MultiDateOnlyRange](./src/Candoumbe.Types/Calendar/MultiDateOnlyRange.cs)

Full changelog at https://github.com/candoumbe/Candoumbe.Types/blob/feature/freeze-fluent-assertions-to-version-7/CHANGELOG.md

Resolves #237