### PR TITLE
🧹 Nightly Pipeline Must Download Required Sdk

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,6 +36,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: 'global.json'
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `NonNegativeLong` type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
 - Added `PositiveLong` type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
 
+### 🛠️ Technical
+- Updated GitHub workflows to download required SDKs when running CI. 
 
 ## [0.2.0] / 2024-12-03
 ### 🚀 New features

--- a/build/Pipelines.cs
+++ b/build/Pipelines.cs
@@ -104,7 +104,7 @@ using Nuke.Common.Tools.GitHub;
     ]
 )]
 [GitHubActions("perf-manual", GitHubActionsImage.Ubuntu2204,
-    AutoGenerate = true,
+    AutoGenerate = false,
     FetchDepth = 0,
     InvokedTargets = [nameof(IBenchmark.Benchmarks)],
     CacheKeyFiles =


### PR DESCRIPTION
### 💥 Breaking changes
• Moved all types from Candoumbe.Types.Numerics namespace from Candoumbe.Types NuGet package into Candoumbe.Types.Numerics NuGet package
• Moved all types from Candoumbe.Types.Calendar namespace from Candoumbe.Types NuGet package into Candoumbe.Types.Calendar NuGet package
### 🚀 New features
• Added NonNegativeLong type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
• Added PositiveLong type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
### 🛠️ Technical
- Updated GitHub workflows to download required SDKs when running CI. 

Full changelog at https://github.com/candoumbe/Candoumbe.Types/blob/coldfix/nightly-pipeline-must-download-required-sdk/CHANGELOG.md