### PR TITLE
🧹 Fix Unit Tests

### DIFF
--- a/test/Candoumbe.Types.UnitTests/Strings/StringSegmentLinkedListTests.cs
+++ b/test/Candoumbe.Types.UnitTests/Strings/StringSegmentLinkedListTests.cs
@@ -347,7 +347,7 @@ public class StringSegmentLinkedListTests(ITestOutputHelper outputHelper)
 
         // Assert
         actual.Should().HaveSameCount(expected);
-        
+
         string actualString = actual.ToStringValue();
         string expectedString = expected.ToStringValue();
         actualString.Should().Be(expectedString);
@@ -552,7 +552,9 @@ public class StringSegmentLinkedListTests(ITestOutputHelper outputHelper)
         StringSegmentLinkedList actual = input.Replace(predicate, replacement);
 
         // Assert
-        actual.Should().ContainInOrder(expected);
+        string actualStr = actual.ToStringValue();
+        outputHelper.WriteLine($"{nameof(actualStr)}: '{actualStr}'");
+        actualStr.Should().Be(expected.ToStringValue());
     }
 
     [Property(Skip = "StringSegmentLinkedList does not handle state properly")]


### PR DESCRIPTION
### 💥 Breaking changes
• Moved all types from Candoumbe.Types.Numerics namespace from Candoumbe.Types NuGet package into Candoumbe.Types.Numerics NuGet package
• Moved all types from Candoumbe.Types.Calendar namespace from Candoumbe.Types NuGet package into Candoumbe.Types.Calendar NuGet package
### 🚀 New features
• Added NonNegativeLong type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
• Added PositiveLong type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
### 🧹 Housekeeping
• Add DotNet.ReproducibleBuilds package to core.props
• Update README.md with new badges for nightly and main branches%2C and mutation testing
• Improve StringSegmentLinkedList.Replace when replacing a string by a string  method to reduce memory allocations
    • Optimize character replacement logic
    • Avoid unnecessary allocations by using ReadOnlyMemory<char> and ReadOnlySpan<char>
    • Refactor code for better readability and performance
### 🛠️ Technical
• Updated GitHub workflows to download required SDKs when running CI. 

Full changelog at https://github.com/candoumbe/Candoumbe.Types/blob/coldfix/fix-unit-tests/CHANGELOG.md