### PR TITLE
🧹 Missing Dotnet Stryker Dependency

### DIFF
--- a/build/Pipelines.csproj
+++ b/build/Pipelines.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageDownload Include="GitVersion.Tool" Version="[6.0.5]"/>
     <PackageDownload Include="CodeCov.Tool" Version="[1.13.0]"/>
+    <PackageDownload Include="dotnet-stryker" Version="[4.5.1]"/>
     <PackageDownload Include="CodecovUploader" Version="[0.8.0]"/>
     <PackageDownload Include="ReportGenerator" Version="[5.1.13]"/>
   </ItemGroup>


### PR DESCRIPTION
### 💥 Breaking changes
• Moved all types from Candoumbe.Types.Numerics namespace from Candoumbe.Types NuGet package into Candoumbe.Types.Numerics NuGet package
• Moved all types from Candoumbe.Types.Calendar namespace from Candoumbe.Types NuGet package into Candoumbe.Types.Calendar NuGet package
### 🚀 New features
• Added NonNegativeLong type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
• Added PositiveLong type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
### 🧹 Housekeeping
• Add DotNet.ReproducibleBuilds package to core.props
• Update [Candoumbe.Pipelines](https://nuget.org/packages/pipelines) to 0.13.2
• Update README.md with new badges for nightly and main branches%2C and mutation testing
• Improve StringSegmentLinkedList.Replace when replacing a string by a string  method to reduce memory allocations
    • Optimize character replacement logic
    • Avoid unnecessary allocations by using ReadOnlyMemory<char> and ReadOnlySpan<char>
    • Refactor code for better readability and performance
### 🛠️ Technical
• Updated GitHub workflows to download required SDKs when running CI. 

Full changelog at https://github.com/candoumbe/Candoumbe.Types/blob/coldfix/missing-dotnet-stryker-dependency/CHANGELOG.md