### PR TITLE
✨ StringSegmentLinkedList.Contains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🚀 New features
 - Added `NonNegativeLong` type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
 - Added `PositiveLong` type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
+- Added `StringSegmentLinkedList.Contains(ReadOnlySpan<char>)` ([#])
+- Added `StringSegmentLinkedList.Contains(ReadOnlySpan<char>, IEqualityComparer<char>)` 
 
 ### 🧹 Housekeeping
 - Add `DotNet.ReproducibleBuilds` package to `core.props`

--- a/test/Candoumbe.Types.UnitTests/Strings/StringSegmentLinkedListTests.cs
+++ b/test/Candoumbe.Types.UnitTests/Strings/StringSegmentLinkedListTests.cs
@@ -606,7 +606,7 @@ public class StringSegmentLinkedListTests(ITestOutputHelper outputHelper)
                 new StringSegmentLinkedList("Hello").Append("world"),
                 "low".AsMemory(),
                 CharComparer.Ordinal,
-                false
+                true
             }
         };
 

--- a/test/Candoumbe.Types.UnitTests/Strings/StringSegmentLinkedListTests.cs
+++ b/test/Candoumbe.Types.UnitTests/Strings/StringSegmentLinkedListTests.cs
@@ -560,4 +560,64 @@ public class StringSegmentLinkedListTests(ITestOutputHelper outputHelper)
     [Property(Skip = "StringSegmentLinkedList does not handle state properly")]
     public Property StringSegmentList_should_works_consistently()
         => new StringSegmentLinkedListSpecification().ToProperty();
+
+
+    [Property]
+    public void Given_an_empty_StringSegmentLinkedList_When_checking_if_it_contains_an_empty_string_Then_the_result_should_be_True()
+    {
+        // Arrange
+        StringSegmentLinkedList emptyList = [];
+
+        // Act
+        bool actual = emptyList.Contains(string.Empty);
+
+        // Assert
+        actual.Should().Be(string.Empty.Contains(string.Empty));
+    }
+
+    public static TheoryData<StringSegmentLinkedList, ReadOnlyMemory<char>, CharComparer, bool> ContainsCases
+        => new()
+        {
+            {
+                new StringSegmentLinkedList("Hello", "world"),
+                "world".AsMemory(),
+                CharComparer.Ordinal,
+                true
+            },
+            {
+                new StringSegmentLinkedList("Hello", "world"),
+                "low".AsMemory(),
+                CharComparer.Ordinal,
+                true
+            },
+            {
+                new StringSegmentLinkedList(@"Hello\*", "world"),
+                @"\*".AsMemory(),
+                CharComparer.Ordinal,
+                true
+            },
+            {
+                new StringSegmentLinkedList(@"Hello\*", "world"),
+                @"\*m".AsMemory(),
+                CharComparer.Ordinal,
+                false
+            },
+            {
+                new StringSegmentLinkedList("Hello").Append("world"),
+                "low".AsMemory(),
+                CharComparer.Ordinal,
+                false
+            }
+        };
+
+    [Theory]
+    [MemberData(nameof(ContainsCases))]
+    public void Given_a_StringSegmentLinkedList_Then_Contains_should_behave_as_expected(StringSegmentLinkedList list, ReadOnlyMemory<char> search, IEqualityComparer<char> comparer, bool expected)
+    {
+        // Act
+        bool actual = list.Contains(search.Span, comparer);
+
+        // Assert
+        actual.Should().Be(expected);
+    }
 }


### PR DESCRIPTION
### 💥 Breaking changes
• Moved all types from Candoumbe.Types.Numerics namespace from Candoumbe.Types NuGet package into Candoumbe.Types.Numerics NuGet package
• Moved all types from Candoumbe.Types.Calendar namespace from Candoumbe.Types NuGet package into Candoumbe.Types.Calendar NuGet package
### 🚀 New features
• Added NonNegativeLong type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
• Added PositiveLong type ([#43](https://github.com/candoumbe/Candoumbe.Types/issues/43))
• Added StringSegmentLinkedList.Contains(ReadOnlySpan<char>) ([#])
• Added StringSegmentLinkedList.Contains(ReadOnlySpan<char>%2C IEqualityComparer<char>) 
### 🧹 Housekeeping
• Add DotNet.ReproducibleBuilds package to core.props
• Update [Candoumbe.Pipelines](https://nuget.org/packages/pipelines) to 0.13.2
• Update README.md with new badges for nightly and main branches%2C and mutation testing
• Improve StringSegmentLinkedList.Replace when replacing a string by a string  method to reduce memory allocations
    • Optimize character replacement logic
    • Avoid unnecessary allocations by using ReadOnlyMemory<char> and ReadOnlySpan<char>
    • Refactor code for better readability and performance
### 🛠️ Technical
• Updated GitHub workflows to download required SDKs when running CI. 

Full changelog at https://github.com/candoumbe/Candoumbe.Types/blob/feature/contains-sequence-of-characters/CHANGELOG.md

Resolves #284