### PR TITLE
✨ Reduce `StringSegmentLinkedList` memory footprint

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -147,6 +147,10 @@
           "type": "boolean",
           "description": "Indicates to open the pull request as 'draft'"
         },
+        "Filter": {
+          "type": "string",
+          "description": "Filter benchmarks to run by their full name (namespace.typeName.methodName) using glob pattern"
+        },
         "GitHubToken": {
           "type": "string",
           "description": "Token used to create a new release in GitHub",
@@ -174,6 +178,11 @@
         "NugetApiKey": {
           "type": "string",
           "description": "Token used to interact with Nuget API",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
+        "NuGetApiKey": {
+          "type": "string",
+          "description": "API Key to use for accessing the NuGet repository",
           "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
         "SkipConfirmation": {

--- a/.nuke/parameters.local.json
+++ b/.nuke/parameters.local.json
@@ -1,5 +1,6 @@
 {
+  "$schema": "./build.schema.json",
   "GitHubToken": "v1:Rgp0YSiizCZNIoK6m7DVObx5tTCZO0lOMOHyWJmvrhv9ImRrGgLZQUnUx7Ny9xPKozoFzcKMFGFAy8fXsJWriultDRHtCZkx54lA2raJGaZpFb+I7hBm7RQLh7K9MuFM",
-  "NugetApiKey": "v1:jPyKrvPYjmdgN0TqM/zAt+aRIBa5q1Tg+BWJYmMyFnyEfBTdIbkknjiVJYT/i0Qk",
+  "NuGetApiKey": "v1:jPyKrvPYjmdgN0TqM/zAt+aRIBa5q1Tg+BWJYmMyFnyEfBTdIbkknjiVJYT/i0Qk",
   "StrykerDashboardApiKey": "v1:07d0pKblcWk/3O9mP3aWBmVU+YATC0me8jgH1du1bnp306X/W4JHZ/82ZeJwdKbW"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### 🚀 New features
+
+- Optimized memory usage of `StringSegmentLinkedList`
+  - Add new constructors for `StringSegmentNode` and `StringSegmentLinkedList`
+  - Improve `Append` and `InsertAt` methods to handle different types of inputs
+  - Add `Compact` method to reduce node count and improve locality
+
+### 🧹 Housekeeping
+- Removed unnecessary imports and simplify code
+- Added performance tests for `StringSegmentLinkedList`
 
 ## [0.4.1] / 2025-08-12
 ### 🐛 Fixes

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageVersion Include="Bogus" Version="35.6.3" />
-    <PackageVersion Include="Candoumbe.Pipelines" Version="0.13.4" />
+    <PackageVersion Include="Candoumbe.Pipelines" Version="1.0.0-rc.25" />
     <PackageVersion Include="Candoumbe.MiscUtilities" Version="0.15.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="FluentAssertions" Version="[7.2.0]" />

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
     ":approveMajorUpdates",

--- a/src/Candoumbe.Types.Calendar/MultiDateOnlyRange.cs
+++ b/src/Candoumbe.Types.Calendar/MultiDateOnlyRange.cs
@@ -297,7 +297,7 @@ public class MultiDateOnlyRange : IEquatable<MultiDateOnlyRange>, IEnumerable<Da
     /// <param name="right">The value to compare to <paramref name="left"/></param>
     /// <returns><see langword="true"/> if <paramref name="left"/> is equal to <paramref name="right"/>; otherwise, <see langword="false"/></returns>
 #else
-    /// <inheritdoc /> 
+    /// <inheritdoc />
 #endif
     public static bool operator ==(MultiDateOnlyRange left, MultiDateOnlyRange right)
         => ( left, right ) switch
@@ -315,7 +315,7 @@ public class MultiDateOnlyRange : IEquatable<MultiDateOnlyRange>, IEnumerable<Da
     /// <param name="right">The value to compare to <paramref name="left"/></param>
     /// <returns><see langword="true"/> if <paramref name="left"/> is not equal to <paramref name="right"/>; otherwise, <see langword="false"/></returns>
 #else
-    /// <inheritdoc /> 
+    /// <inheritdoc />
 #endif
     public static bool operator !=(MultiDateOnlyRange left, MultiDateOnlyRange right) => !(left == right);
 }

--- a/src/Candoumbe.Types.Calendar/MultiDateTimeRange.cs
+++ b/src/Candoumbe.Types.Calendar/MultiDateTimeRange.cs
@@ -52,7 +52,7 @@ public class MultiDateTimeRange : IEquatable<MultiDateTimeRange>, IEnumerable<Da
 #if !NETSTANDARD2_1_OR_GREATER || !NET5_0_OR_GREATER
         _ranges = new HashSet<DateTimeRange>();
 #else
-        _ranges = new HashSet<DateTimeRange>(ranges.Length); 
+        _ranges = new HashSet<DateTimeRange>(ranges.Length);
 #endif
         foreach (DateTimeRange range in ranges.OrderBy(x => x.Start))
         {

--- a/src/Candoumbe.Types.Core/Range.cs
+++ b/src/Candoumbe.Types.Core/Range.cs
@@ -18,7 +18,7 @@ public abstract class Range<TBound> : IRange<Range<TBound>, TBound>, ICanReprese
 /// <summary>
 /// Builds a new instance of <see cref="Range{TBound}"/> which spans from <see cref="Start"/> to <see cref="End"/>
 /// </summary>
-/// <param name="Start">The lowest bound</param>    
+/// <param name="Start">The lowest bound</param>
 /// <param name="End">The highest bound</param>
 /// <typeparam name="TBound">Type of the <see cref="Start"/> and <see cref="End"/> bounds.</typeparam>
 public abstract record Range<TBound>(TBound Start, TBound End) : IRange<Range<TBound>, TBound>, ICanRepresentEmpty<Range<TBound>, TBound>

--- a/src/Candoumbe.Types.Strings/StringSegmentLinkedList.cs
+++ b/src/Candoumbe.Types.Strings/StringSegmentLinkedList.cs
@@ -13,11 +13,54 @@ namespace Candoumbe.Types.Strings;
 /// </summary>
 /// <remarks>
 /// This implementation is specifically designed to not allow appending <see cref="StringSegment.Empty"/> values.
+/// <para>The implementation provides four properties that can be used to tune the performance of the linked list:</para>
+/// <list type="bullet">
+///   <item>
+///     <term><see cref="ChunkSize"/></term>
+///     <description>The size of the chunks used to compact the list.</description>
+///   </item>
+///   <item>
+///     <term><see cref="MaxSmallSegmentLength"/></term>
+///     <description>The length threshold under which a segment is considered small.</description>
+///   </item>
+///   <item>
+///     <term><see cref="MaxNodeCountBeforeCompact"/></term>
+///     <description>The maximum number of nodes to keep before compacting the list.</description>
+///   </item>
+///   <item>
+///     <term><see cref="ReplaceCloneThreshold"/></term>
+///     <description>The number of characters beyond which replace operations uses a clone/copy strategy.</description>
+///   </item>
+/// </list>
+///
+///
 /// </remarks>
 public class StringSegmentLinkedList : IEnumerable<ReadOnlyMemory<char>>, IEquatable<StringSegmentLinkedList>
 {
     private StringSegmentNode _head;
     private StringSegmentNode _tail;
+
+    /// <summary>
+    /// Size of the chunks used to compact the list.
+    /// </summary>
+    public int ChunkSize { get; set; } = 4_096;
+
+    /// <summary>
+    /// Length of the smallest segment that will be kept in the list.
+    /// </summary>
+    public int MaxSmallSegmentLength { get; set; } = 64;
+
+    /// <summary>
+    /// Number of nodes that will be kept in the list before compacting it.
+    /// </summary>
+    public int MaxNodeCountBeforeCompact { get; set; } = 10_000;
+
+    /// <summary>
+    /// Number of characters threshold beyond which a "replace" operation adopts a different strategy.
+    /// For example, cloning/copying a block instead of replacing character by character.
+    /// </summary>
+    public int ReplaceCloneThreshold { get; set; } = 1_000_000;
+
 
     /// <summary>
     /// Builds a new instance of <see cref="StringSegmentLinkedList"/> that is empty.
@@ -369,12 +412,6 @@ public class StringSegmentLinkedList : IEnumerable<ReadOnlyMemory<char>>, IEquat
     /// Gets the number of nodes in the current linked list
     /// </summary>
     public int Count { get; private set; }
-
-    // Configuration/Heuristics
-    public int ChunkSize { get; set; } = 4096;
-    public int MaxSmallSegmentLength { get; set; } = 64;
-    public int MaxNodeCountBeforeCompact { get; set; } = 10_000;
-    public int ReplaceCloneThreshold { get; set; } = 1_000_000;
 
     /// <summary>
     /// Compacts the list into larger chunks to reduce node count and improve locality.

--- a/src/Candoumbe.Types.Strings/StringSegmentLinkedList.cs
+++ b/src/Candoumbe.Types.Strings/StringSegmentLinkedList.cs
@@ -249,7 +249,7 @@ public class StringSegmentLinkedList : IEnumerable<ReadOnlyMemory<char>>, IEquat
         }
         else
         {
-            _tail!.Next = newNode;
+            _tail.Next = newNode;
             _tail = newNode;
         }
 
@@ -430,18 +430,6 @@ public class StringSegmentLinkedList : IEnumerable<ReadOnlyMemory<char>>, IEquat
             int pos = 0;
             StringSegmentLinkedList compacted = new();
 
-            void Flush()
-            {
-                if (pos == 0)
-                {
-                    return;
-                }
-
-                string chunk = new string(buffer, 0, pos);
-                compacted.Append(chunk);
-                pos = 0;
-            }
-
             StringSegmentNode node = _head;
             while (node is not null)
             {
@@ -471,6 +459,16 @@ public class StringSegmentLinkedList : IEnumerable<ReadOnlyMemory<char>>, IEquat
             _tail = compacted._tail;
             Count = compacted.Count;
             return this;
+
+            void Flush()
+            {
+                if (pos is not 0)
+                {
+                    string chunk = new string(buffer, 0, pos);
+                    compacted.Append(chunk);
+                    pos = 0;
+                }
+            }
         }
         finally
         {

--- a/src/Candoumbe.Types.Strings/StringSegmentNode.cs
+++ b/src/Candoumbe.Types.Strings/StringSegmentNode.cs
@@ -1,7 +1,4 @@
 using System;
-#if NET8_0_OR_GREATER
-using System.Collections.Immutable;
-#endif
 using System.Diagnostics.CodeAnalysis;
 
 namespace Candoumbe.Types.Strings;
@@ -23,16 +20,32 @@ internal sealed class StringSegmentNode : IEquatable<StringSegmentNode>
     public StringSegmentNode Next { get; internal set; }
 
     /// <summary>
-    /// Initializes a new instance of the StringSegmentNode class with the specified value.
+    /// Builds a new instance of <see cref="StringSegmentNode"/> initialized with the specified <paramref name="value"/>.
     /// </summary>
-    /// <param name="value">The StringSegment value to be stored in the node.</param>
-    public StringSegmentNode(ReadOnlySpan<char> value)
+    /// <param name="value">The value to store in the node.</param>
+    public StringSegmentNode(ReadOnlyMemory<char> value)
     {
-#if NET8_0_OR_GREATER
-        Value = value.ToImmutableArray().AsMemory();
-#else
-        Value = value.ToArray();
-#endif
+        Value = value;
+        Next = null;
+    }
+
+    /// <summary>
+    /// Builds a new instance of <see cref="StringSegmentNode"/> initialized with the specified <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value"></param>
+    public StringSegmentNode(string value)
+    {
+        Value = value?.AsMemory() ?? ReadOnlyMemory<char>.Empty;
+        Next = null;
+    }
+
+    /// <summary>
+    /// Builds a new instance of <see cref="StringSegmentNode"/> initialized with the specified <paramref name="span"/>.
+    /// </summary>
+    /// <param name="span"></param>
+    public StringSegmentNode(ReadOnlySpan<char> span)
+    {
+        Value = span.ToArray();
         Next = null;
     }
 

--- a/test/Candoumbe.Types.Calendar.UnitTests/MultiDateTimeRangeTests.cs
+++ b/test/Candoumbe.Types.Calendar.UnitTests/MultiDateTimeRangeTests.cs
@@ -476,14 +476,14 @@ public class MultiDateTimeRangeTests(ITestOutputHelper outputHelper)
         // Arrange
         MultiDateTimeRange range = multiDateTimeRangeGenerator.Item;
         MultiDateTimeRange expected = range.Complement();
-        
+
         // Act
         MultiDateTimeRange actual = -range;
-        
+
         // Assert
         actual.Should().BeEquivalentTo(expected);
     }
-    
+
     [Fact]
     public void Overlaps_returns_false_when_no_overlapping_date_time_ranges()
     {
@@ -524,8 +524,8 @@ public class MultiDateTimeRangeTests(ITestOutputHelper outputHelper)
         => new TheoryData<MultiDateTimeRange, object, bool, string> ()
         {
             {
-                
-                
+
+
                 /*
                  * multirange : |
                  * other    : |

--- a/test/Candoumbe.Types.Numerics.UnitTests/Generators/ValueGenerators.cs
+++ b/test/Candoumbe.Types.Numerics.UnitTests/Generators/ValueGenerators.cs
@@ -26,7 +26,7 @@ internal static class ValueGenerators
                                                                          .Generator
                                                                          .Select(value => NonNegativeInteger.From(value.Item))
         .ToArbitrary();
-    
+
     public static Arbitrary<NonNegativeLong> NonNegativeLongs() => ArbMap.Default.ArbFor<long>()
         .Filter(value => value >= 0)
         .Generator

--- a/test/Candoumbe.Types.Strings.PerformanceTests/ConcatVsStringSegmentLinkedList.cs
+++ b/test/Candoumbe.Types.Strings.PerformanceTests/ConcatVsStringSegmentLinkedList.cs
@@ -52,7 +52,7 @@ public class ConcatVsStringSegmentLinkedList
         {
             list.Append(word);
         }
-        
+
         return list.ToStringValue();
     }
 }

--- a/test/Candoumbe.Types.Strings.PerformanceTests/ConcatVsStringSegmentLinkedList.cs
+++ b/test/Candoumbe.Types.Strings.PerformanceTests/ConcatVsStringSegmentLinkedList.cs
@@ -2,9 +2,8 @@ using System.Text;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using Bogus;
-using Candoumbe.Types.Strings;
 
-namespace Candoumbe.Types.PerformanceTests;
+namespace Candoumbe.Types.Strings.PerformanceTests;
 
 [MemoryDiagnoser]
 [SimpleJob(RuntimeMoniker.Net80)]

--- a/test/Candoumbe.Types.Strings.PerformanceTests/ReplaceCharByChar.cs
+++ b/test/Candoumbe.Types.Strings.PerformanceTests/ReplaceCharByChar.cs
@@ -14,9 +14,9 @@ public class CharReplacementBenchmark
     private const char NewChar = '0';
     private StringBuilder _stringBuilder;
     private StringSegmentLinkedList _stringSegments;
-    
+
     [Params(10, 100, 1000, 10000)]
-    public int NodeCount {get; set;} 
+    public int NodeCount {get; set;}
 
     [GlobalSetup]
     public void SetUp()
@@ -28,11 +28,11 @@ public class CharReplacementBenchmark
             _stringBuilder.Append(InputString);
             _stringSegments.Append(InputString);
         }
-        
+
         InputString = _stringBuilder.ToString();
-        
+
     }
-    
+
     [Benchmark(Baseline = true)]
     public string ReplaceUsingStringReplace() => InputString.Replace(OldChar, NewChar);
 
@@ -42,11 +42,11 @@ public class CharReplacementBenchmark
         _stringBuilder.Replace(OldChar, NewChar);
         return _stringBuilder.ToString();
     }
-    
+
     [Benchmark]
     public string NoReplacement() => _stringBuilder.ToString();
-    
+
     [Benchmark]
     public string ReplacementWithStringSegmentLinkedList() => _stringSegments.Replace(OldChar, NewChar).ToStringValue();
-    
+
 }

--- a/test/Candoumbe.Types.Strings.PerformanceTests/StringSegmentLinkedListBenchmarks.cs
+++ b/test/Candoumbe.Types.Strings.PerformanceTests/StringSegmentLinkedListBenchmarks.cs
@@ -24,14 +24,15 @@ public class StringSegmentLinkedListBenchmarks
             .Select(_ => RandomWord(rnd, 5, 20))
             .ToArray();
 
-        char[] buffer = ArrayPool<char>.Shared.Rent(1_048_576);
+        const int length = 1_048_576;
+        char[] buffer = ArrayPool<char>.Shared.Rent(length);
         try
         {
-            for (int i = 0; i < 1_048_576; i++)
+            for (int i = 0; i < length; i++)
             {
                 buffer[i] = rnd.NextDouble() < HitRate ? 'x' : 'y';
             }
-            _oneMbText = new string(buffer, 0, 1_048_576);
+            _oneMbText = new string(buffer, 0, length);
         }
         finally
         {
@@ -91,7 +92,7 @@ public class StringSegmentLinkedListBenchmarks
             list.Append(s);
         }
         string before = list.ToStringValue();
-        list.Compact(4096);
+        list.Compact();
         string after = list.ToStringValue();
         return before.Length + after.Length;
     }

--- a/test/Candoumbe.Types.Strings.PerformanceTests/StringSegmentLinkedListBenchmarks.cs
+++ b/test/Candoumbe.Types.Strings.PerformanceTests/StringSegmentLinkedListBenchmarks.cs
@@ -1,0 +1,98 @@
+using System.Buffers;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Order;
+
+namespace Candoumbe.Types.Strings.PerformanceTests;
+
+[MemoryDiagnoser]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+public class StringSegmentLinkedListBenchmarks
+{
+    private string[] _smallWords;
+    private string _oneMbText;
+
+    [Params(0.0, 0.01, 0.10, 0.50)]
+    public double HitRate { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Random rnd = new(42);
+        _smallWords = Enumerable.Range(0, 10_000)
+            .Select(_ => RandomWord(rnd, 5, 20))
+            .ToArray();
+
+        char[] buffer = ArrayPool<char>.Shared.Rent(1_048_576);
+        try
+        {
+            for (int i = 0; i < 1_048_576; i++)
+            {
+                buffer[i] = rnd.NextDouble() < HitRate ? 'x' : 'y';
+            }
+            _oneMbText = new string(buffer, 0, 1_048_576);
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(buffer);
+        }
+    }
+
+    private static string RandomWord(Random rnd, int min, int max)
+    {
+        int len = rnd.Next(min, max);
+        char[] chars = new char[len];
+        for (int i = 0; i < len; i++)
+        {
+            chars[i] = (char)('a' + rnd.Next(0, 26));
+        }
+        return new string(chars);
+    }
+
+
+    [Benchmark]
+    [BenchmarkCategory( "Append10kSmall")]
+    public int Append_10k_small_strings_total_length()
+    {
+        StringSegmentLinkedList list = new();
+        foreach (string s in _smallWords)
+        {
+            list.Append(s);
+        }
+        return list.GetTotalLength();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("ReplaceStringOn1MB")]
+    public int Replace_char_to_char_on_1MB()
+    {
+        StringSegmentLinkedList list = new(_oneMbText);
+        StringSegmentLinkedList replaced = list.Replace('x', 'z');
+        return replaced.GetTotalLength();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory( "ReplaceStringToStringOn1MB")]
+    public int Replace_string_to_string_on_1MB()
+    {
+        StringSegmentLinkedList list = new(_oneMbText);
+        StringSegmentLinkedList replaced = list.Replace("xy", "zz");
+        return replaced.GetTotalLength();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("ToStringValue_Compact")]
+    public int ToStringValue_before_after_Compact()
+    {
+        StringSegmentLinkedList list = new();
+        foreach (string s in _smallWords)
+        {
+            list.Append(s);
+        }
+        string before = list.ToStringValue();
+        list.Compact(4096);
+        string after = list.ToStringValue();
+        return before.Length + after.Length;
+    }
+}

--- a/test/Candoumbe.Types.Strings.UnitTests/StringSegmentLinkedListSpecification.cs
+++ b/test/Candoumbe.Types.Strings.UnitTests/StringSegmentLinkedListSpecification.cs
@@ -24,10 +24,19 @@ public class StringSegmentLinkedListSpecification : Machine<StringSegmentLinkedL
         }
 
         /// <inheritdoc />
-        public override StringSegmentLinkedList Actual() => new(_value.Span, [.. _additionalValues ]);
+        public override StringSegmentLinkedList Actual()
+        {
+            var list = new StringSegmentLinkedList(_value);
+            foreach (string s in _additionalValues)
+            {
+                list.Append(s);
+            }
+            return list;
+        }
 
         /// <inheritdoc />
-        public override StringSegmentLinkedListState Model() => new ([ _value.ToString(), ..  _additionalValues ], string.Concat([ _value, ..  _additionalValues ]));
+        public override StringSegmentLinkedListState Model()
+            => new ([ _value.ToString(), ..  _additionalValues ], string.Concat(new[] { _value.ToString() }.Concat(_additionalValues)));
     }
 
     /// <inheritdoc />

--- a/test/Candoumbe.Types.Strings.UnitTests/StringSegmentLinkedListTests.cs
+++ b/test/Candoumbe.Types.Strings.UnitTests/StringSegmentLinkedListTests.cs
@@ -266,18 +266,18 @@ public class StringSegmentLinkedListTests(ITestOutputHelper outputHelper)
         StringSegmentLinkedList actualList = initialList.Append(segment);
 
         // Assert
-        actualList.Count.Should().Be(2);
+        actualList.Count.Should().Be(1);
         actualList.GetTotalLength().Should().Be(segment.Length);
     }
 
     [Fact]
-    public void Given_initial_empty_list_Then_Count_should_return_one()
+    public void Given_initial_empty_list_Then_Count_should_return_zero()
     {
         // Arrange
         StringSegmentLinkedList initialList = new(StringSegment.Empty);
 
         // Act
-        initialList.Count.Should().Be(1);
+        initialList.Count.Should().Be(0);
         initialList.GetTotalLength().Should().Be(0);
     }
 


### PR DESCRIPTION
### 🚀 New features
• Optimized memory usage of StringSegmentLinkedList
  • Add new constructors for StringSegmentNode and StringSegmentLinkedList
  • Improve Append and InsertAt methods to handle different types of inputs
  • Add Compact method to reduce node count and improve locality
### 🧹 Housekeeping
• Removed unnecessary imports and simplify code
• Added performance tests for StringSegmentLinkedList

Full changelog at https://github.com/candoumbe/Candoumbe.Types/blob/feature/reduce-memory-footprint/CHANGELOG.md