### PR TITLE
🧹 Reactivate mutation tests

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -56,6 +56,11 @@ jobs:
         with:
           name: unit-tests
           path: output/artifacts/tests-results/unit-tests
+      - name: 'Publish: mutation-tests'
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-tests
+          path: output/artifacts/tests-results/mutation-tests
       - name: 'Publish: packages'
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -66,6 +66,11 @@ jobs:
         with:
           name: unit-tests-coverage-history
           path: output/artifacts/reports/coverage-history/unit-tests-coverage-history
+      - name: 'Publish: mutation-tests'
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-tests
+          path: output/artifacts/tests-results/mutation-tests
       - name: 'Publish: packages'
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/nightly-manual.yml
+++ b/.github/workflows/nightly-manual.yml
@@ -36,18 +36,28 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('src/**/*.csproj', 'test/**/*.csproj', 'test/**/*/stryker-config.json', 'test/**/*/xunit.runner.json') }}
-      - name: 'Run: Tests, Pack'
-        run: ./build.cmd Tests Pack
+      - name: 'Run: MutationTests, Pack'
+        run: ./build.cmd MutationTests Pack
         env:
           NugetApiKey: ${{ secrets.NUGET_API_KEY }}
           CodecovToken: ${{ secrets.CODECOV_TOKEN }}
           StrykerDashboardApiKey: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Publish: mutation-tests'
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-tests
+          path: output/artifacts/tests-results/mutation-tests
       - name: 'Publish: unit-tests'
         uses: actions/upload-artifact@v4
         with:
           name: unit-tests
           path: output/artifacts/tests-results/unit-tests
+      - name: 'Publish: packages'
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages
+          path: output/artifacts/packages
       - name: 'Publish: unit-tests-coverage'
         uses: actions/upload-artifact@v4
         with:
@@ -58,8 +68,3 @@ jobs:
         with:
           name: unit-tests-coverage-history
           path: output/artifacts/reports/coverage-history/unit-tests-coverage-history
-      - name: 'Publish: packages'
-        uses: actions/upload-artifact@v4
-        with:
-          name: packages
-          path: output/artifacts/packages

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,18 +46,28 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('src/**/*.csproj', 'test/**/*.csproj', 'test/**/*/stryker-config.json', 'test/**/*/xunit.runner.json') }}
-      - name: 'Run: Tests, Pack'
-        run: ./build.cmd Tests Pack
+      - name: 'Run: MutationTests, Pack'
+        run: ./build.cmd MutationTests Pack
         env:
           NugetApiKey: ${{ secrets.NUGET_API_KEY }}
           CodecovToken: ${{ secrets.CODECOV_TOKEN }}
           StrykerDashboardApiKey: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Publish: mutation-tests'
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-tests
+          path: output/artifacts/tests-results/mutation-tests
       - name: 'Publish: unit-tests'
         uses: actions/upload-artifact@v4
         with:
           name: unit-tests
           path: output/artifacts/tests-results/unit-tests
+      - name: 'Publish: packages'
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages
+          path: output/artifacts/packages
       - name: 'Publish: unit-tests-coverage'
         uses: actions/upload-artifact@v4
         with:
@@ -68,8 +78,3 @@ jobs:
         with:
           name: unit-tests-coverage-history
           path: output/artifacts/reports/coverage-history/unit-tests-coverage-history
-      - name: 'Publish: packages'
-        uses: actions/upload-artifact@v4
-        with:
-          name: packages
-          path: output/artifacts/packages

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -36,7 +36,6 @@
         "Hotfix",
         "Pack",
         "Publish",
-        "RegenerateWorkflow",
         "Release",
         "ReportUnitTestCoverage",
         "Restore",

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -34,8 +34,10 @@
         "Compile",
         "Feature",
         "Hotfix",
+        "MutationTests",
         "Pack",
         "Publish",
+        "RegenerateWorkflow",
         "Release",
         "ReportUnitTestCoverage",
         "Restore",
@@ -196,6 +198,11 @@
         "Solution": {
           "type": "string",
           "description": "Path to a solution file that is automatically loaded"
+        },
+        "StrykerDashboardApiKey": {
+          "type": "string",
+          "description": "API KEY used to submit mutation report to a stryker dashboard",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
         "Title": {
           "type": "string",

--- a/build/Pipelines.cs
+++ b/build/Pipelines.cs
@@ -61,7 +61,7 @@ using static Nuke.Common.Tools.DotNet.DotNetTasks;
         "LICENSE"
     ],
     InvokedTargets = [
-        nameof(Tests),
+        nameof(IMutationTest.MutationTests),
         nameof(IPushNugetPackages.Pack)
     ],
     CacheKeyFiles =
@@ -85,7 +85,7 @@ using static Nuke.Common.Tools.DotNet.DotNetTasks;
     FetchDepth = 0,
     On = [GitHubActionsTrigger.WorkflowDispatch],
     InvokedTargets = [
-        nameof(Tests),
+        nameof(IMutationTest.MutationTests),
         nameof(IPushNugetPackages.Pack)
     ],
     CacheKeyFiles =
@@ -164,8 +164,7 @@ public class Pipelines : EnhancedNukeBuild,
     IPack,
     IPushNugetPackages,
     ICreateGithubRelease,
-    IGitFlowWithPullRequest,
-    ICanRegenerateGitHubWorkflows
+    IGitFlowWithPullRequest
 {
     [Required]
     [Solution]
@@ -219,7 +218,6 @@ public class Pipelines : EnhancedNukeBuild,
                                                                     )
                                                      );
 
-    // TODO reintroduce mutation tests once https://github.com/stryker-mutator/issues/318 is resolved.
     // ///<inheritdoc/>
     // IEnumerable<MutationProjectConfiguration> IMutationTest.MutationTestsProjects =>
     // [

--- a/build/Pipelines.cs
+++ b/build/Pipelines.cs
@@ -158,13 +158,13 @@ public class Pipelines : EnhancedNukeBuild,
     IUnitTest,
     IBenchmark,
     IHaveGitVersion,
-    // TODO reintroduce mutation tests once https://github.com/stryker-mutator/issues/318 is resolved.
-    //IMutationTest,
+    IMutationTest,
     IReportUnitTestCoverage,
     IPack,
     IPushNugetPackages,
     ICreateGithubRelease,
-    IGitFlowWithPullRequest
+    IGitFlowWithPullRequest,
+    ICanRegenerateGitHubWorkflows
 {
     [Required]
     [Solution]
@@ -218,18 +218,18 @@ public class Pipelines : EnhancedNukeBuild,
                                                                     )
                                                      );
 
-    // ///<inheritdoc/>
-    // IEnumerable<MutationProjectConfiguration> IMutationTest.MutationTestsProjects =>
-    // [
-    //     .. s_projects.Select(projectName => new MutationProjectConfiguration(Solution.AllProjects.Single(project => string.Equals(project.Name, projectName, StringComparison.InvariantCultureIgnoreCase)),
-    //                                      this.Get<IHaveSolution>().Solution.GetAllProjects("*.UnitTests"),
-    //                                      (this.Get<IHaveTestDirectory>().TestDirectory / $"{projectName}.UnitTests" / "stryker-config.json") switch
-    //                                      {
-    //                                          var configFilePath when configFilePath.FileExists() => configFilePath,
-    //                                          _ => null
-    //                                      }))
-    //         .Where(mutationTest => mutationTest.ConfigurationFile is not null)
-    // ];
+    ///<inheritdoc/>
+    IEnumerable<MutationProjectConfiguration> IMutationTest.MutationTestsProjects =>
+    [
+        .. s_projects.Select(projectName => new MutationProjectConfiguration(Solution.AllProjects.Single(project => string.Equals(project.Name, projectName, StringComparison.InvariantCultureIgnoreCase)),
+                                         this.Get<IHaveSolution>().Solution.GetAllProjects("*.UnitTests"),
+                                         (this.Get<IHaveTestDirectory>().TestDirectory / $"{projectName}.UnitTests" / "stryker-config.json") switch
+                                         {
+                                             var configFilePath when configFilePath.FileExists() => configFilePath,
+                                             _ => null
+                                         }))
+            .Where(mutationTest => mutationTest.ConfigurationFile is not null)
+    ];
 
     ///<inheritdoc/>
     IEnumerable<AbsolutePath> IPack.PackableProjects => this.Get<IHaveSourceDirectory>().SourceDirectory.GlobFiles("**/*.csproj");

--- a/build/Pipelines.csproj
+++ b/build/Pipelines.csproj
@@ -19,7 +19,7 @@
     <PackageDownload Include="CodeCov.Tool" Version="[1.13.0]" />
     <PackageDownload Include="CodecovUploader" Version="[0.8.0]" />
     <PackageDownload Include="ReportGenerator" Version="[5.1.13]" />
-    <PackageDownload Include="dotnet-stryker" Version="[4.6.0]" />
+    <PackageDownload Include="dotnet-stryker" Version="[4.9.1]" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
feat: reintroduce mutation tests and update workflows

- Reintroduce `IMutationTest` with updated configuration
- Add tasks for `MutationTests` and `RegenerateWorkflow` in build schema
- Update GitHub workflows to publish mutation tests artifacts
- Add `StrykerDashboardApiKey` configuration to build schema