### PR TITLE
:broom: Remove unnecessary code

### DIFF
--- a/build/Pipelines.csproj
+++ b/build/Pipelines.csproj
@@ -19,7 +19,7 @@
     <PackageDownload Include="CodeCov.Tool" Version="[1.13.0]" />
     <PackageDownload Include="CodecovUploader" Version="[0.8.0]" />
     <PackageDownload Include="ReportGenerator" Version="[5.1.13]" />
-    <PackageDownload Include="dotnet-stryker" Version="[4.9.1]" />
+    <PackageDownload Include="dotnet-stryker" Version="[4.10.0]" />
   </ItemGroup>
 
 </Project>

--- a/src/Candoumbe.Types.Calendar/DateOnlyRange.cs
+++ b/src/Candoumbe.Types.Calendar/DateOnlyRange.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Numerics;
+using Candoumbe.Types.Core;
 
 namespace Candoumbe.Types.Calendar;
 

--- a/src/Candoumbe.Types.Calendar/DateTimeRange.cs
+++ b/src/Candoumbe.Types.Calendar/DateTimeRange.cs
@@ -2,6 +2,7 @@
 // Licenced under GNU General Public Licence, version 3.0"
 
 using System;
+using Candoumbe.Types.Core;
 
 #if NET7_0_OR_GREATER
 using System.Numerics;
@@ -64,8 +65,8 @@ public record DateTimeRange : Range<DateTime>, IFormattable
         null => -1,
         _ => Start.CompareTo(other.Start) switch
         {
-            int and 0 => End.CompareTo(other.End),
-            int value => value
+            0 => End.CompareTo(other.End),
+            var value => value
         }
     };
 
@@ -107,7 +108,7 @@ public record DateTimeRange : Range<DateTime>, IFormattable
 #if NET5_0_OR_GREATER
             result = this with { Start = GetMinimum(Start, other.Start), End = GetMaximum(other.End, End) };
 #else
-            result = new(GetMinimum(Start, other.Start), GetMaximum(other.End, End));
+            result = new DateTimeRange(GetMinimum(Start, other.Start), GetMaximum(other.End, End));
 #endif
         }
         else

--- a/src/Candoumbe.Types.Calendar/DateTimeRange.cs
+++ b/src/Candoumbe.Types.Calendar/DateTimeRange.cs
@@ -2,6 +2,7 @@
 // Licenced under GNU General Public Licence, version 3.0"
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Candoumbe.Types.Core;
 
 #if NET7_0_OR_GREATER
@@ -19,7 +20,7 @@ public class DateTimeRange : Range<DateTime>, IFormattable
     , ICanRepresentEmpty<DateTimeRange, DateTime>
     , IRange<DateTimeRange, DateTime>
 #else
-public record DateTimeRange : Range<DateTime>, IFormattable
+public record DateTimeRange : Range<DateTime>, IFormattable, IComparable<DateTimeRange>
 #endif
 #if NET7_0_OR_GREATER
     , IAdditionOperators<DateTimeRange, DateTimeRange, DateTimeRange>
@@ -27,7 +28,7 @@ public record DateTimeRange : Range<DateTime>, IFormattable
 #endif
 {
     /// <summary>
-    /// A <see cref="DateTimeRange"/> that cannot contains other <see cref="DateTimeRange"/> range.
+    /// A <see cref="DateTimeRange"/> that cannot contain other <see cref="DateTimeRange"/> range.
     /// </summary>
     public static DateTimeRange Empty => new(DateTime.MinValue, DateTime.MinValue);
 
@@ -71,7 +72,11 @@ public record DateTimeRange : Range<DateTime>, IFormattable
     };
 
     ///<inheritdoc/>
+#if NET
+    public string ToString([StringSyntax(StringSyntaxAttribute.DateTimeFormat)] string format, IFormatProvider provider)
+#else
     public string ToString(string format, IFormatProvider provider)
+#endif
         => (Start == End)
             ? Start.ToString(format, provider)
             :$"{Start.ToString(format, provider)} - {End.ToString(format, provider)}";
@@ -98,18 +103,14 @@ public record DateTimeRange : Range<DateTime>, IFormattable
     /// <exception cref="InvalidOperationException">if current instance does not overlap or is not continuous with <paramref name="other"/>.</exception>
     public DateTimeRange Merge(DateTimeRange other)
     {
-        DateTimeRange result = Empty;
+        DateTimeRange result;
         if (other.IsEmpty())
         {
             result = this;
         }
         else if (Overlaps(other) || IsContiguousWith(other))
         {
-#if NET5_0_OR_GREATER
-            result = this with { Start = GetMinimum(Start, other.Start), End = GetMaximum(other.End, End) };
-#else
             result = new DateTimeRange(GetMinimum(Start, other.Start), GetMaximum(other.End, End));
-#endif
         }
         else
         {
@@ -119,7 +120,16 @@ public record DateTimeRange : Range<DateTime>, IFormattable
         return result;
     }
 
+#if !NET8_0_OR_GREATER
+    ///<summary>
+    /// Adds two <see cref="DateTimeRange"/> together and computes their sum
+    ///</summary>
+    ///<param name="left">Left operand</param>
+    ///<param name="right">Right operand</param>
+    ///<returns>A new <see cref="DateTimeRange"/> that spans over both <paramref name="left"/> and <paramref name="right"/>.</returns>
+#else
     ///<inheritdoc/>
+#endif
     public static DateTimeRange operator +(DateTimeRange left, DateTimeRange right) => left?.Merge(right);
 
     /// <summary>
@@ -148,7 +158,7 @@ public record DateTimeRange : Range<DateTime>, IFormattable
     /// Computes  <see cref="DateTimeRange"/> value that is common between the current instance and <paramref name="other"/>.
     /// </summary>
     /// <remarks>
-    /// This methods relies on <see cref="Range{T}.Overlaps(Range{T})"/> to see if there can be a intersection with <paramref name="other"/>.
+    /// This method relies on <see cref="Range{T}.Overlaps(Range{T})"/> to see if there can be an intersection with <paramref name="other"/>.
     /// </remarks>
     /// <param name="other">The other instance to test</param>
     /// <returns>a <see cref="DateTimeRange"/> that represent the overlap between the current instance and <paramref name="other"/> or <see cref="Empty"/> when no intersection found.</returns>
@@ -158,11 +168,7 @@ public record DateTimeRange : Range<DateTime>, IFormattable
 
         if (Overlaps(other))
         {
-#if NET5_0_OR_GREATER
-            result = this with { Start = GetMaximum(Start, other.Start), End = GetMinimum(End, other.End) };
-#else
-            result = new(GetMaximum(Start, other.Start), GetMinimum(End, other.End));
-#endif
+            result = new DateTimeRange(GetMaximum(Start, other.Start), GetMinimum(End, other.End));
         }
 
         return result;
@@ -192,14 +198,23 @@ public record DateTimeRange : Range<DateTime>, IFormattable
     public static bool operator !=(DateTimeRange left, DateTimeRange right) => !(left == right);
 #endif
 
-    ///<inheritdoc/>
-    public bool Overlaps(DateTimeRange other)
+    /// <summary>
+    /// Checks if the current instance overlaps with <paramref name="other"/>.
+    /// </summary>
+    /// <remarks>
+    /// This method extends <see cref="Range{T}.Overlaps(Range{T})"/> to take into account <see cref="Infinite"/> and <see cref="Empty"/> ranges.
+    /// </remarks>
+    /// <param name="other"></param>
+    /// <returns><see langword="true"/> if the current instance overlaps <paramref name="other"/> and <see langword="false"/> otherwise.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="other"/> is <see langword="null"/>.</exception>
+    public virtual bool Overlaps(DateTimeRange other)
         => (IsInfinite() && other.IsEmpty())
            || (IsEmpty() && other.IsInfinite())
            || base.Overlaps(other);
 
     /// <inheritdoc />
-    public bool Overlaps(DateTime other) => Start <= other && other <= End;
+    public override bool Overlaps(DateTime other) => Start <= other && other <= End;
+
 
 #if !NET5_0_OR_GREATER
     ///<inheritdoc/>
@@ -222,7 +237,6 @@ public record DateTimeRange : Range<DateTime>, IFormattable
 
     ///<inheritdoc/>
     public virtual bool Equals(DateTimeRange other) => other is not null &&
-               base.Equals(other) &&
                Start == other.Start &&
                End == other.End;
 }

--- a/src/Candoumbe.Types.Calendar/TimeOnlyRange.cs
+++ b/src/Candoumbe.Types.Calendar/TimeOnlyRange.cs
@@ -299,7 +299,7 @@ public record TimeOnlyRange : Range<TimeOnly>
             _ => Start.CompareTo(other.Start) switch
             {
                 0 => End.CompareTo(other.End),
-                int value => value
+                var value => value
             }
         };
 }

--- a/src/Candoumbe.Types.Calendar/TimeOnlyRange.cs
+++ b/src/Candoumbe.Types.Calendar/TimeOnlyRange.cs
@@ -4,6 +4,7 @@
 #if NET6_0_OR_GREATER
 using System;
 using System.Diagnostics;
+using Candoumbe.Types.Core;
 #if NET7_0_OR_GREATER
 using System.Numerics;
 #endif

--- a/src/Candoumbe.Types.Core/ICanRepresentEmpty.cs
+++ b/src/Candoumbe.Types.Core/ICanRepresentEmpty.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Candoumbe.Types;
+namespace Candoumbe.Types.Core;
 
 /// <summary>
 /// Defines contract for intervals that can be empty.

--- a/src/Candoumbe.Types.Core/ICanRepresentInfinite.cs
+++ b/src/Candoumbe.Types.Core/ICanRepresentInfinite.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Candoumbe.Types;
+namespace Candoumbe.Types.Core;
 
 /// <summary>
 /// Marker interface for intervals that can represent an interval in such way that, for any given <typeparamref name="TBound"/> value,

--- a/src/Candoumbe.Types.Core/IRange.cs
+++ b/src/Candoumbe.Types.Core/IRange.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Candoumbe.Types;
+namespace Candoumbe.Types.Core;
 
 /// <summary>
 /// It's quite common to see comparisons where a value is checked against an interval of values. Ranges are most of the time handled by a pair of values,

--- a/src/Candoumbe.Types.Core/Range.cs
+++ b/src/Candoumbe.Types.Core/Range.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Candoumbe.Types;
+namespace Candoumbe.Types.Core;
 
 #if !NET5_0_OR_GREATER
 /// <summary>

--- a/src/Candoumbe.Types.Core/Range.cs
+++ b/src/Candoumbe.Types.Core/Range.cs
@@ -89,7 +89,7 @@ public abstract record Range<TBound>(TBound Start, TBound End) : IRange<Range<TB
     /// </summary>
     /// <param name="other">The other instance</param>
     /// <returns><see langword="true"/> if the current instance overlaps <paramref name="other"/> and <see langword="false"/> otherwise.</returns>
-    public virtual bool Overlaps(Range<TBound> other) => other is not null && ( Start.CompareTo(other.Start), Start.CompareTo(other.End), End.CompareTo(other.Start), End.CompareTo(other.End) ) switch
+    public virtual bool Overlaps(Range<TBound> other) => other is not null && (Start.CompareTo(other.Start), Start.CompareTo(other.End), End.CompareTo(other.Start), End.CompareTo(other.End)) switch
     {
         (> 0, < 0, _, _) => true,
         // current :   |-------|
@@ -125,12 +125,11 @@ public abstract record Range<TBound>(TBound Start, TBound End) : IRange<Range<TB
             }
         };
 
-#if !NET
     /// <inheritdoc/>
-    public virtual bool Overlaps(TBound other) => (Start.CompareTo(other), End.CompareTo(other)) switch
-    {
-        (<= 0, <= 0) => true,
-        _ => false
-    };
-#endif
+    public virtual bool Overlaps(TBound other)
+        => (Start.CompareTo(other), End.CompareTo(other)) switch
+        {
+            (>= 0, <= 0) => true,
+            _ => false
+        };
 }

--- a/test/Candoumbe.Types.ArchitecturalTests/NumericsArchitecture.cs
+++ b/test/Candoumbe.Types.ArchitecturalTests/NumericsArchitecture.cs
@@ -5,6 +5,7 @@ using ArchUnitNET.Fluent.Conditions;
 using ArchUnitNET.Loader;
 using ArchUnitNET.xUnitV3;
 using Candoumbe.Types.Calendar;
+using Candoumbe.Types.Core;
 using Candoumbe.Types.Numerics;
 using Candoumbe.Types.Strings;
 using Architecture = ArchUnitNET.Domain.Architecture;

--- a/test/Candoumbe.Types.Calendar.UnitTests/DateOnlyRangeTests.cs
+++ b/test/Candoumbe.Types.Calendar.UnitTests/DateOnlyRangeTests.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Bogus;
-using Candoumbe.Types.Calendar.UnitTests.Generators;
+using Candoumbe.Types.Calendar.UnitTests.Helpers;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using FsCheck;
@@ -18,7 +18,7 @@ namespace Candoumbe.Types.Calendar.UnitTests;
 [UnitTest]
 public class DateOnlyRangeTests(ITestOutputHelper outputHelper)
 {
-    private static readonly Faker Faker = new();
+    private static readonly Faker s_faker = new();
 
     [Property(Arbitrary = [typeof(ValueGenerators)])]
     public void Given_start_gt_end_Constructor_should_feed_Properties_accordingly(DateOnly start)
@@ -39,7 +39,7 @@ public class DateOnlyRangeTests(ITestOutputHelper outputHelper)
     public void Given_start_and_end_Constructor_should_feed_Properties_accordingly(DateOnly start)
     {
         // Arrange
-        DateOnly end = Faker.Date.FutureDateOnly(refDate: start);
+        DateOnly end = s_faker.Date.FutureDateOnly(refDate: start);
 
         // Act
         DateOnlyRange range = new(start, end);
@@ -54,7 +54,7 @@ public class DateOnlyRangeTests(ITestOutputHelper outputHelper)
     {
         // Arrange
         DateOnly end = reference;
-        DateOnly start = Faker.Date.RecentDateOnly(refDate: reference);
+        DateOnly start = s_faker.Date.RecentDateOnly(refDate: reference);
 
         DateOnlyRange first = new(start, end);
         DateOnlyRange other = new(start, end);
@@ -232,7 +232,7 @@ public class DateOnlyRangeTests(ITestOutputHelper outputHelper)
     {
         // Arrange
         DateOnlyRange range = rangeGenerator.Item;
-        DateOnly value = Faker.Date.BetweenDateOnly(range.Start, range.Start);
+        DateOnly value = s_faker.Date.BetweenDateOnly(range.Start, range.Start);
 
         // Assert
         return range.Overlaps(value).ToProperty();
@@ -339,8 +339,8 @@ public class DateOnlyRangeTests(ITestOutputHelper outputHelper)
     public void Given_non_empty_TimeOnlyRange_When_merging_with_an_other_TimeOnlyRange_that_does_not_overlaps_nor_is_contiguous_Merge_should_throw_InvalidOperationException(DateOnly date)
     {
         // Arrange
-        DateOnlyRange left = new(date.AddDays(1), Faker.Date.FutureDateOnly(refDate: date.AddDays(2)));
-        DateOnlyRange right = new(Faker.Date.RecentDateOnly(refDate: date.AddDays(-2)), date.AddDays(-1));
+        DateOnlyRange left = new(date.AddDays(1), s_faker.Date.FutureDateOnly(refDate: date.AddDays(2)));
+        DateOnlyRange right = new(s_faker.Date.RecentDateOnly(refDate: date.AddDays(-2)), date.AddDays(-1));
 
         outputHelper.WriteLine($"{nameof(left)} : {left}");
         outputHelper.WriteLine($"{nameof(right)} : {right}");
@@ -488,11 +488,11 @@ public class DateOnlyRangeTests(ITestOutputHelper outputHelper)
     public void Given_DateOnlyRange_is_not_empty_and_not_infinite_When_value_is_between_Start_and_End_Then_Contains_should_returns_true(DateOnly date)
     {
         // Arrange
-        DateOnly start = Faker.PickRandom(Faker.Date.RecentDateOnly(refDate: date),
-                                          Faker.Date.PastDateOnly(refDate: date));
+        DateOnly start = s_faker.PickRandom(s_faker.Date.RecentDateOnly(refDate: date),
+                                          s_faker.Date.PastDateOnly(refDate: date));
 
-        DateOnly end = Faker.PickRandom(Faker.Date.SoonDateOnly(refDate: date),
-                                        Faker.Date.FutureDateOnly(refDate: date));
+        DateOnly end = s_faker.PickRandom(s_faker.Date.SoonDateOnly(refDate: date),
+                                        s_faker.Date.FutureDateOnly(refDate: date));
 
         DateOnlyRange dateRange = (start == end) switch
         {
@@ -516,10 +516,10 @@ public class DateOnlyRangeTests(ITestOutputHelper outputHelper)
 
         DateOnlyRange dateRange = new(start, end);
 
-        DateOnly value = Faker.PickRandom(Faker.Date.RecentDateOnly(refDate: start.AddDays(-1)),
-                                          Faker.Date.PastDateOnly(refDate: start.AddDays(-1)),
-                                          Faker.Date.SoonDateOnly(refDate: end.AddDays(1)),
-                                          Faker.Date.FutureDateOnly(refDate: end.AddDays(1)));
+        DateOnly value = s_faker.PickRandom(s_faker.Date.RecentDateOnly(refDate: start.AddDays(-1)),
+                                          s_faker.Date.PastDateOnly(refDate: start.AddDays(-1)),
+                                          s_faker.Date.SoonDateOnly(refDate: end.AddDays(1)),
+                                          s_faker.Date.FutureDateOnly(refDate: end.AddDays(1)));
 
         // Act
         bool actual = dateRange.Overlaps(value);
@@ -558,11 +558,11 @@ public class DateOnlyRangeTests(ITestOutputHelper outputHelper)
     public void Given_two_ranges_non_null_left_and_right_When_left_is_before_right_Then_Compare_should_return_minus_one()
     {
         // Arrange
-        DateOnly reference = Faker.Date.FutureDateOnly();
-        DateOnlyRange left = new(Faker.Date.PastDateOnly(refDate: reference), Faker.Date.FutureDateOnly(refDate: reference));
+        DateOnly reference = s_faker.Date.FutureDateOnly();
+        DateOnlyRange left = new(s_faker.Date.PastDateOnly(refDate: reference), s_faker.Date.FutureDateOnly(refDate: reference));
 
-        DateOnly rightStart = Faker.Date.FutureDateOnly(refDate: reference);
-        DateOnlyRange right = new(rightStart, Faker.Date.FutureDateOnly(refDate: rightStart));
+        DateOnly rightStart = s_faker.Date.FutureDateOnly(refDate: reference);
+        DateOnlyRange right = new(rightStart, s_faker.Date.FutureDateOnly(refDate: rightStart));
 
         outputHelper.WriteLine($"left is {left}");
         outputHelper.WriteLine($"right is {right}");

--- a/test/Candoumbe.Types.Calendar.UnitTests/DateTimeRangeTests.cs
+++ b/test/Candoumbe.Types.Calendar.UnitTests/DateTimeRangeTests.cs
@@ -2,8 +2,10 @@
 // Licenced under GNU General Public Licence, version 3.0"
 
 using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Bogus;
-using Candoumbe.Types.Calendar.UnitTests.Generators;
+using Candoumbe.Types.Calendar.UnitTests.Helpers;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using FsCheck;
@@ -18,7 +20,7 @@ namespace Candoumbe.Types.Calendar.UnitTests;
 [UnitTest]
 public class DateTimeRangeTests(ITestOutputHelper outputHelper)
 {
-    private static readonly Faker Faker = new();
+    private static readonly Faker s_faker = new();
 
     [Property(Arbitrary = [typeof(ValueGenerators)])]
     public void Given_start_gt_end_Constructor_should_feed_Properties_accordingly(DateTime start)
@@ -37,7 +39,7 @@ public class DateTimeRangeTests(ITestOutputHelper outputHelper)
     public void Given_start_and_end_Constructor_should_feed_Properties_accordingly(DateTime start)
     {
         // Arrange
-        DateTime end = Faker.Date.Future(refDate: start);
+        DateTime end = s_faker.Date.Future(refDate: start);
 
         // Act
         DateTimeRange range = new(start, end);
@@ -52,7 +54,7 @@ public class DateTimeRangeTests(ITestOutputHelper outputHelper)
     {
         // Arrange
         DateTime end = reference;
-        DateTime start = Faker.Date.Recent(refDate: reference);
+        DateTime start = s_faker.Date.Recent(refDate: reference);
 
         DateTimeRange first = new(start, end);
         DateTimeRange other = new(start, end);
@@ -105,7 +107,7 @@ public class DateTimeRangeTests(ITestOutputHelper outputHelper)
     public void Given_two_non_empty_DateTimeRange_instances_when_first_ends_where_other_starts_Abuts_should_return_true(DateTime reference)
     {
         // Arrange
-        DateTime start = Faker.Date.Recent(refDate: reference);
+        DateTime start = s_faker.Date.Recent(refDate: reference);
         DateTime end = reference;
 
         DateTimeRange current = new(start, reference);
@@ -120,7 +122,7 @@ public class DateTimeRangeTests(ITestOutputHelper outputHelper)
     }
 
     [Property(Arbitrary = [typeof(ValueGenerators)])]
-    public Property Given_two_DateTimeRange_instances_IsContiguous_should_be_symetric(DateTimeRange left, DateTimeRange right)
+    public Property Given_two_DateTimeRange_instances_IsContiguous_should_be_symmetric(DateTimeRange left, DateTimeRange right)
     {
         outputHelper.WriteLine($"{nameof(left)}: {left}");
         outputHelper.WriteLine($"{nameof(right)}: {right}");
@@ -181,7 +183,7 @@ public class DateTimeRangeTests(ITestOutputHelper outputHelper)
         // Assert
         action.Should()
               .Throw<InvalidOperationException>("the two dates do not overlap").Which.Message
-              .Should().NotBeNullOrEmpty("the message can be usefull for troubleshooting purposes");
+              .Should().NotBeNullOrEmpty("the message can be useful for troubleshooting purposes");
     }
 
     public static TheoryData<DateTimeRange, DateTimeRange, bool> OverlapsCases
@@ -283,7 +285,7 @@ public class DateTimeRangeTests(ITestOutputHelper outputHelper)
     public void Given_a_range_When_a_datetime_value_is_between_start_and_end_Then_Overlaps_should_return_true(DateTimeRange range)
     {
         // Arrange
-        DateTime value = Faker.Date.Between(range.Start, range.End);
+        DateTime value = s_faker.Date.Between(range.Start, range.End);
 
         // Act
         bool actual = range.Overlaps(value);
@@ -295,6 +297,10 @@ public class DateTimeRangeTests(ITestOutputHelper outputHelper)
     [Property(Arbitrary = [typeof(ValueGenerators)])]
     public Property Overlaps_should_be_symmetric(DateTimeRange left, DateTimeRange right)
         => (left.Overlaps(right) == right.Overlaps(left)).ToProperty();
+
+    [Property(Arbitrary = [typeof(ValueGenerators)])]
+    public Property Overlaps_should_be_reflexive(DateTimeRange range)
+        => range.Overlaps(range).ToProperty();
 
     [Property(Arbitrary = [typeof(ValueGenerators)])]
     public void Given_AllTime_when_testing_overlap_with_any_other_DateTimeRange_Overlaps_should_be_true(DateTimeRange other)
@@ -477,7 +483,7 @@ public class DateTimeRangeTests(ITestOutputHelper outputHelper)
     }
 
     [Property(Arbitrary = [typeof(ValueGenerators)])]
-    public Property Intersect_should_be_symetric(DateTimeRange left, DateTimeRange right)
+    public Property Intersect_should_be_symmetric(DateTimeRange left, DateTimeRange right)
         => (left.Intersect(right) == right.Intersect(left)).ToProperty();
 
     [Property(Arbitrary = [typeof(ValueGenerators)])]
@@ -522,7 +528,7 @@ public class DateTimeRangeTests(ITestOutputHelper outputHelper)
     {
         // Arrange
         DateTimeRange range = rangeGenerator.Item;
-        DateTime value = Faker.Date.Between(range.Start, range.Start);
+        DateTime value = s_faker.Date.Between(range.Start, range.Start);
 
         // Assert
         return range.Overlaps(value).ToProperty();
@@ -537,10 +543,10 @@ public class DateTimeRangeTests(ITestOutputHelper outputHelper)
 
         DateTimeRange dateRange = new(start, end);
 
-        DateTime value = Faker.PickRandom(Faker.Date.Recent(refDate: start.AddDays(-1)),
-                                          Faker.Date.Past(refDate: start.AddDays(-1)),
-                                          Faker.Date.Soon(refDate: end.AddDays(1)),
-                                          Faker.Date.Future(refDate: end.AddDays(1)));
+        DateTime value = s_faker.PickRandom(s_faker.Date.Recent(refDate: start.AddDays(-1)),
+                                          s_faker.Date.Past(refDate: start.AddDays(-1)),
+                                          s_faker.Date.Soon(refDate: end.AddDays(1)),
+                                          s_faker.Date.Future(refDate: end.AddDays(1)));
 
         // Act
         bool actual = dateRange.Overlaps(value);
@@ -561,5 +567,105 @@ public class DateTimeRangeTests(ITestOutputHelper outputHelper)
         // Assert
         actual.Should().Be(range);
 
+    }
+
+    public static TheoryData<DateTimeRange, DateTimeRange, bool, string> EqualsCases
+    {
+        get
+        {
+            TheoryData<DateTimeRange, DateTimeRange, bool, string> cases = new ()
+            {
+                {
+                    new DateTimeRange(1.January(1990), 6.January(1990)),
+                    new DateTimeRange(1.January(1990), 6.January(1990)),
+                    true,
+                    "Left and right represents the same value"
+                },
+                {
+                    new DateTimeRange(1.January(1990), 6.January(1990)),
+                    new DateTimeRange(1.January(1990), 7.January(1990)),
+                    false,
+                    "Different end date"
+                },
+                {
+                    DateTimeRange.Empty,
+                    DateTimeRange.Infinite,
+                    false,
+                    "Left is empty and right is infinite"
+                },
+                {
+                    new DateTimeRange(1.January(1990), 6.January(1990)),
+                    new DateTimeRange(6.January(1990), 7.January(1990)),
+                    false,
+                    "Left date abuts right date"
+                },
+                {
+                    new DateTimeRange(1.January(1990), 7.January(1990)),
+                    new DateTimeRange(6.January(1990), 8.January(1990)),
+                    false,
+                    "Left date overlaps right date"
+                },
+                {
+                    new DateTimeRange(1.January(1990), 7.January(1990)),
+                    null,
+                    false,
+                    "Comparing to null should return false"
+                }
+            };
+
+            return cases;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(EqualsCases))]
+    public void Equals_should_behave_as_expected(DateTimeRange left, DateTimeRange other, bool expected, string reason)
+    {
+        // Arrange
+
+        // Act
+        bool actual = left.Equals(other);
+
+        // Assert
+        actual.Should().Be(expected, reason);
+    }
+
+    [Property(Arbitrary = [typeof(ValueGenerators)])]
+    public Property Equals_should_be_symmetric(DateTimeRange left, DateTimeRange right)
+    {
+        outputHelper.WriteLine($"{nameof(left)}: {left}");
+        outputHelper.WriteLine($"{nameof(right)}: {right}");
+
+        // Act and Assert
+        return (left.Equals(right) == right.Equals(left)).ToProperty();
+    }
+
+    public static TheoryData<DateTimeRange, string, IFormatProvider, string> ToStringCases
+    {
+        get
+        {
+            TheoryData<DateTimeRange, string, IFormatProvider, string> cases = new();
+            {
+                const string format = "yyyy-MM-dd";
+
+                {
+                    DateTimeRange range = new (1.January(1990).Add(12.Hours()), 6.January(1990).Add(13.Hours()));
+                    cases.Add(range, format, CultureInfo.GetCultureInfo("fr"), "1990-01-01 - 1990-01-06");
+                }
+            }
+
+            return cases;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ToStringCases))]
+    public void Produces_expected_string_when_using_ToString_with_a_format(DateTimeRange range, [StringSyntax(StringSyntaxAttribute.DateTimeFormat)]string format, IFormatProvider formatProvider, string expected)
+    {
+        // Act
+        string actual = range.ToString(format, formatProvider);
+
+        // Assert
+        actual.Should().Be(expected);
     }
 }

--- a/test/Candoumbe.Types.Calendar.UnitTests/Helpers/ValueGenerators.cs
+++ b/test/Candoumbe.Types.Calendar.UnitTests/Helpers/ValueGenerators.cs
@@ -5,7 +5,7 @@ using System;
 using FsCheck;
 using FsCheck.Fluent;
 
-namespace Candoumbe.Types.Calendar.UnitTests.Generators;
+namespace Candoumbe.Types.Calendar.UnitTests.Helpers;
 
 /// <summary>
 /// Utility class for generating custom <see cref="Arbitrary{T}"/> used by property based tests.

--- a/test/Candoumbe.Types.Calendar.UnitTests/MultiDateOnlyRangeTests.cs
+++ b/test/Candoumbe.Types.Calendar.UnitTests/MultiDateOnlyRangeTests.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
-using Candoumbe.Types.Calendar.UnitTests.Generators;
+using Candoumbe.Types.Calendar.UnitTests.Helpers;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using FsCheck;

--- a/test/Candoumbe.Types.Calendar.UnitTests/MultiDateTimeRangeTests.cs
+++ b/test/Candoumbe.Types.Calendar.UnitTests/MultiDateTimeRangeTests.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using Candoumbe.Types.Calendar.UnitTests.Generators;
+using Candoumbe.Types.Calendar.UnitTests.Helpers;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using FsCheck;

--- a/test/Candoumbe.Types.Calendar.UnitTests/MultiTimeOnlyRangeTests.cs
+++ b/test/Candoumbe.Types.Calendar.UnitTests/MultiTimeOnlyRangeTests.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using Candoumbe.Types.Calendar.UnitTests.Generators;
+using Candoumbe.Types.Calendar.UnitTests.Helpers;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using FsCheck;
@@ -125,8 +125,8 @@ public class MultiTimeOnlyRangeTests(ITestOutputHelper outputHelper)
                         new TimeOnlyRange(TimeOnly.FromTimeSpan(09.Hours()), TimeOnly.FromTimeSpan(14.Hours())),
                         new TimeOnlyRange(TimeOnly.FromTimeSpan(12.Hours()), TimeOnly.FromTimeSpan(18.Hours())),
                     ],
-                    ranges => ranges.Once()
-                              && ranges.Once(range => range == new TimeOnlyRange(TimeOnly.FromTimeSpan(5.Hours()),
+                    ranges => ranges.Once() &&
+                              ranges.Once(range => range == new TimeOnlyRange(TimeOnly.FromTimeSpan(5.Hours()),
                                   TimeOnly.FromTimeSpan(18.Hours())))
 
                 }
@@ -174,8 +174,8 @@ public class MultiTimeOnlyRangeTests(ITestOutputHelper outputHelper)
                                     .BeEmpty("Both left and right ranges are empty"),
             _ => range.Should()
                        .HaveCount(2).And
-                       .ContainSingle(range => range == right).And
-                       .ContainSingle(range => range == left)
+                       .ContainSingle(item => item == right).And
+                       .ContainSingle(item => item == left)
         };
     }
 

--- a/test/Candoumbe.Types.Calendar.UnitTests/TimeOnlyRangeTests.cs
+++ b/test/Candoumbe.Types.Calendar.UnitTests/TimeOnlyRangeTests.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Bogus;
-using Candoumbe.Types.Calendar.UnitTests.Generators;
+using Candoumbe.Types.Calendar.UnitTests.Helpers;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using FsCheck;
@@ -19,7 +19,7 @@ namespace Candoumbe.Types.Calendar.UnitTests;
 [UnitTest]
 public class TimeOnlyRangeTests(ITestOutputHelper outputHelper)
 {
-    private static readonly Faker Faker = new();
+    private static readonly Faker s_faker = new();
 
     [Property(Arbitrary = [typeof(ValueGenerators)])]
     public void Given_start_and_end_Constructor_should_feed_Properties_accordingly(TimeOnly start, TimeOnly end)
@@ -37,7 +37,7 @@ public class TimeOnlyRangeTests(ITestOutputHelper outputHelper)
     {
         // Arrange
         TimeOnly end = reference;
-        TimeOnly start = Faker.Date.RecentTimeOnly(mins: (int)(reference - TimeOnly.MinValue).TotalMinutes, refTime: reference);
+        TimeOnly start = s_faker.Date.RecentTimeOnly(mins: (int)(reference - TimeOnly.MinValue).TotalMinutes, refTime: reference);
 
         TimeOnlyRange first = new(start, end);
 
@@ -60,7 +60,7 @@ public class TimeOnlyRangeTests(ITestOutputHelper outputHelper)
     }
 
     [Property(Arbitrary = [typeof(ValueGenerators)])]
-    public Property Given_two_TimeOnlyRange_instances_Overlaps_should_be_symetric(TimeOnlyRange left, TimeOnlyRange right)
+    public Property Given_two_TimeOnlyRange_instances_Overlaps_should_be_symmetric(TimeOnlyRange left, TimeOnlyRange right)
     {
         outputHelper.WriteLine($"{nameof(left)}: {left}");
         outputHelper.WriteLine($"{nameof(right)}: {right}");
@@ -84,7 +84,7 @@ public class TimeOnlyRangeTests(ITestOutputHelper outputHelper)
     }
 
     [Property(Arbitrary = [typeof(ValueGenerators)])]
-    public Property Given_two_TimeOnlyRange_instances_IsContiguous_should_be_symetric(TimeOnlyRange left, TimeOnlyRange right)
+    public Property Given_two_TimeOnlyRange_instances_IsContiguous_should_be_symmetric(TimeOnlyRange left, TimeOnlyRange right)
     {
         outputHelper.WriteLine($"{nameof(left)}: {left}");
         outputHelper.WriteLine($"{nameof(right)}: {right}");
@@ -560,8 +560,8 @@ public class TimeOnlyRangeTests(ITestOutputHelper outputHelper)
     public void Given_TimeOnlyRange_is_not_empty_and_not_infinite_When_value_is_between_Start_and_End_Overlaps_should_returns_Yes(TimeOnly value)
     {
         // Arrange
-        TimeOnly start = Faker.Date.RecentTimeOnly(refTime: value);
-        TimeOnly end = Faker.Date.SoonTimeOnly(refTime: value);
+        TimeOnly start = s_faker.Date.RecentTimeOnly(refTime: value);
+        TimeOnly end = s_faker.Date.SoonTimeOnly(refTime: value);
 
         TimeOnlyRange timeRange = (start == end) switch
         {
@@ -586,8 +586,8 @@ public class TimeOnlyRangeTests(ITestOutputHelper outputHelper)
 
         TimeOnlyRange timeRange = new(start, end);
 
-        TimeOnly value = Faker.PickRandom(Faker.Date.RecentTimeOnly(refTime: start.AddMinutes(-1)),
-                                          Faker.Date.SoonTimeOnly(refTime: end.AddMinutes(1)));
+        TimeOnly value = s_faker.PickRandom(s_faker.Date.RecentTimeOnly(refTime: start.AddMinutes(-1)),
+                                          s_faker.Date.SoonTimeOnly(refTime: end.AddMinutes(1)));
 
         // Act
         bool result = timeRange.Overlaps(value);


### PR DESCRIPTION
### 🚀 New features
• Added net10.0 TFM support ([#346](https://github.com/candoumbe/candoumbe.types/issues/346))
• Added netstandard2.0 TFM support ([#355](https://github.com/candoumbe/candoumbe.types/issues/355))
• Added StringSegmentLinkedList.EndsWith(ReadOnlySpan<char>%2CIEqualityComparer<char>) method ([#287](https://github.com/candoumbe/candoumbe.types/issues/287))
• Optimized memory usage of StringSegmentLinkedList
  • Added new constructors for StringSegmentNode and StringSegmentLinkedList
  • Improved Append and InsertAt methods to handle different types of inputs
  • Added Compact method to reduce node count and improve locality
### 🧹 Housekeeping
• Removed unnecessary imports and simplify code
• Added performance tests for StringSegmentLinkedList

Full changelog at https://github.com/candoumbe/Candoumbe.Types/blob/coldfix/remove-unnecessary-code/CHANGELOG.md